### PR TITLE
feat(macos): поддержка WireGuard на macOS

### DIFF
--- a/backend/autostart.go
+++ b/backend/autostart.go
@@ -17,9 +17,52 @@ func setAutoStart(v bool) error {
 		return setAutoStartLinux(v)
 	case "windows":
 		return setAutoStartWindows(v)
+	case "darwin":
+		return setAutoStartDarwin(v)
 	default:
 		return fmt.Errorf("unsupported: %s", runtime.GOOS)
 	}
+}
+
+const launchAgentLabel = "com.pwdtt.autostart"
+
+func setAutoStartDarwin(v bool) error {
+	dir := filepath.Join(os.Getenv("HOME"), "Library", "LaunchAgents")
+	path := filepath.Join(dir, launchAgentLabel+".plist")
+	if !v {
+		os.Remove(path)
+		return nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	// .app: .../PWDTT.app/Contents/MacOS/pwdtt → запускаем через open,
+	// чтобы поднялся именно бандл, а не голый бинарник
+	appPath := exe
+	if idx := strings.Index(exe, ".app/Contents/MacOS/"); idx != -1 {
+		appPath = exe[:idx+len(".app")]
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	content := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>%s</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/open</string>
+		<string>%s</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>
+`, launchAgentLabel, appPath)
+	return os.WriteFile(path, []byte(content), 0o644)
 }
 
 func setAutoStartLinux(v bool) error {

--- a/backend/cmd_darwin.go
+++ b/backend/cmd_darwin.go
@@ -1,0 +1,5 @@
+package backend
+
+import "os/exec"
+
+func hideWindow(_ *exec.Cmd) {}

--- a/backend/update.go
+++ b/backend/update.go
@@ -63,11 +63,38 @@ func CheckUpdate(currentVersion string) (*UpdateInfo, error) {
 
 	// Ищем ссылку на скачивание для текущей ОС
 	var downloadURL string
-	osName := runtime.GOOS // "linux" или "windows"
+	osName := runtime.GOOS // "linux", "windows" или "darwin"
+	// Возможные синонимы ОС в имени ассета
+	osAliases := []string{osName}
+	if osName == "darwin" {
+		osAliases = append(osAliases, "macos", "mac", "osx")
+	}
+	// Подходящие маркеры архитектуры (darwin собирается universal)
+	archMarkers := []string{runtime.GOARCH}
+	if osName == "darwin" {
+		archMarkers = append(archMarkers, "universal", "arm64", "amd64")
+	} else {
+		archMarkers = append(archMarkers, "amd64", "x86_64")
+	}
 	for _, asset := range release.Assets {
 		name := strings.ToLower(asset.Name)
-		if strings.Contains(name, osName) && strings.Contains(name, "amd64") {
-			downloadURL = asset.BrowserDownloadURL
+		osOK := false
+		for _, a := range osAliases {
+			if strings.Contains(name, a) {
+				osOK = true
+				break
+			}
+		}
+		if !osOK {
+			continue
+		}
+		for _, m := range archMarkers {
+			if strings.Contains(name, m) {
+				downloadURL = asset.BrowserDownloadURL
+				break
+			}
+		}
+		if downloadURL != "" {
 			break
 		}
 	}

--- a/backend/wg.go
+++ b/backend/wg.go
@@ -33,10 +33,13 @@ type WG struct {
 	activeRoutes   []string
 	activeRoutesMu sync.Mutex
 
-	// Windows-specific
+	// Windows/macOS userspace-specific
 	activeDevice        *device.Device
 	activeTun           tun.Device
 	activeExcludeRoutes []string
+
+	// macOS-specific: соединение с привилегированным helper-процессом
+	helperConn *net.UnixConn
 }
 
 type wgLogFunc func(msg string)
@@ -50,6 +53,8 @@ func (w *WG) Apply(conf string, turnIPs []string, logf wgLogFunc) error {
 		return w.applyLinux(conf, turnIPs, logf)
 	case "windows":
 		return w.applyWindows(conf, turnIPs, logf)
+	case "darwin":
+		return w.applyDarwin(conf, turnIPs, logf)
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
@@ -61,6 +66,8 @@ func (w *WG) Teardown() {
 		w.teardownLinux()
 	case "windows":
 		w.teardownWindows()
+	case "darwin":
+		w.teardownDarwin()
 	}
 }
 

--- a/backend/wg_darwin.go
+++ b/backend/wg_darwin.go
@@ -1,0 +1,377 @@
+package backend
+
+// macOS: создание utun требует root, поэтому туннель поднимается в два процесса:
+//
+//  1. Приложение (без прав) слушает unix-сокет и через osascript
+//     ("with administrator privileges" — системный диалог пароля) запускает
+//     этот же бинарник в режиме `--wg-helper` от root.
+//  2. Helper (root) создаёт utun, назначает адрес/MTU, прописывает маршруты
+//     и передаёт fd интерфейса приложению через SCM_RIGHTS. Дальше helper
+//     висит на сокете: команда "down" или обрыв соединения (краш приложения)
+//     → снимает exclude-маршруты и выходит.
+//  3. Приложение оборачивает полученный fd в tun.Device и крутит userspace
+//     wireguard-go без прав. Ключи helper'у не передаются.
+//
+// Туннельные маршруты (-interface utunN) умирают вместе с utun, когда
+// приложение закрывает fd — явно их снимать не нужно.
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun"
+)
+
+// wgHelperMsg — JSON-строка протокола helper→app (одна на строку).
+// Сообщение с непустым Name несёт fd интерфейса в OOB (SCM_RIGHTS).
+type wgHelperMsg struct {
+	Log   string `json:"log,omitempty"`
+	Error string `json:"error,omitempty"`
+	Name  string `json:"name,omitempty"`
+}
+
+// ═══════════════════════════════════════════════════
+// APP SIDE
+// ═══════════════════════════════════════════════════
+
+func (w *WG) applyDarwin(confText string, turnIPs []string, logf wgLogFunc) error {
+	w.teardownDarwin()
+
+	addr, mtuStr, allowedIPs, wgConf := parseWGConfig(confText)
+	if addr == "" {
+		return fmt.Errorf("Address not found in wg config")
+	}
+	mtu := 1300
+	if mtuStr != "" {
+		fmt.Sscanf(mtuStr, "%d", &mtu)
+	}
+
+	// Exclude-маршруты — через физический gateway, мимо туннеля
+	var excludes []string
+	for _, ip := range turnIPs {
+		excludes = append(excludes, ip+"/32")
+	}
+	excludes = append(excludes, vkExcludeCIDRs...)
+	for _, dns := range localDNSServers() {
+		excludes = append(excludes, dns+"/32")
+	}
+
+	// Туннельные маршруты: полный дефолт заменяем на split-default,
+	// чтобы не трогать физический default route
+	var tunnels []string
+	for _, cidr := range allowedIPs {
+		if cidr == "0.0.0.0/0" {
+			tunnels = append(tunnels, "0.0.0.0/1", "128.0.0.0/1")
+		} else {
+			tunnels = append(tunnels, cidr)
+		}
+	}
+
+	// Сокет, на который выйдет helper
+	sockDir, err := os.MkdirTemp("", "pwdtt-wg-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(sockDir)
+	sock := filepath.Join(sockDir, "h.sock")
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: sock, Net: "unix"})
+	if err != nil {
+		return err
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		ln.Close()
+		return err
+	}
+
+	shellCmd := fmt.Sprintf("%s --wg-helper -sock %s -addr %s -mtu %d -exclude %s -tunnel %s >/dev/null 2>&1 &",
+		shellQuote(exe), shellQuote(sock), shellQuote(addr), mtu,
+		shellQuote(strings.Join(excludes, ",")), shellQuote(strings.Join(tunnels, ",")))
+	osa := fmt.Sprintf("do shell script %q with administrator privileges", shellCmd)
+
+	logf("Запрос прав администратора для настройки туннеля…")
+	if out, err := exec.Command("osascript", "-e", osa).CombinedOutput(); err != nil {
+		ln.Close()
+		return fmt.Errorf("права администратора не получены: %w — %s", err, strings.TrimSpace(string(out)))
+	}
+
+	ln.SetDeadline(time.Now().Add(30 * time.Second))
+	hconn, err := ln.AcceptUnix()
+	ln.Close()
+	if err != nil {
+		return fmt.Errorf("helper не вышел на связь: %w", err)
+	}
+
+	tunFile, utunName, err := recvTunFD(hconn, logf)
+	if err != nil {
+		hconn.Close()
+		return err
+	}
+	hconn.SetReadDeadline(time.Time{})
+	logf(fmt.Sprintf("Интерфейс %s получен от helper", utunName))
+
+	tunDev, err := tun.CreateTUNFromFile(tunFile, 0) // mtu уже выставлен helper'ом
+	if err != nil {
+		hconn.Close()
+		return fmt.Errorf("wrap TUN: %w", err)
+	}
+
+	logger := &device.Logger{
+		Verbosef: func(format string, args ...interface{}) {},
+		Errorf:   func(format string, args ...interface{}) { logf(fmt.Sprintf(format, args...)) },
+	}
+	dev := device.NewDevice(tunDev, conn.NewDefaultBind(), logger)
+
+	logf("Применение WireGuard конфига (uapi)")
+	if err := dev.IpcSetOperation(strings.NewReader(uapiConf(wgConf))); err != nil {
+		dev.Close()
+		hconn.Close()
+		return fmt.Errorf("IpcSet: %w", err)
+	}
+	if err := dev.Up(); err != nil {
+		dev.Close()
+		hconn.Close()
+		return fmt.Errorf("device up: %w", err)
+	}
+
+	w.activeTun = tunDev
+	w.activeDevice = dev
+	w.helperConn = hconn
+	w.activeExcludeRoutes = excludes
+	w.activeRoutesMu.Lock()
+	w.activeRoutes = tunnels
+	w.activeRoutesMu.Unlock()
+
+	logf(fmt.Sprintf("Туннель %s поднят, маршруты: %v", utunName, tunnels))
+	return nil
+}
+
+func (w *WG) teardownDarwin() {
+	// Останавливаем движок и закрываем fd — utun и его маршруты исчезают сами
+	if w.activeDevice != nil {
+		w.activeDevice.Close()
+		w.activeDevice = nil
+	}
+	if w.activeTun != nil {
+		_ = w.activeTun.Close()
+		w.activeTun = nil
+	}
+
+	// Просим helper снять exclude-маршруты (без пароля) и ждём его выхода
+	if w.helperConn != nil {
+		_, _ = w.helperConn.Write([]byte("down\n"))
+		_ = w.helperConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		_, _ = io.Copy(io.Discard, w.helperConn)
+		w.helperConn.Close()
+		w.helperConn = nil
+	}
+
+	w.activeRoutesMu.Lock()
+	w.activeRoutes = nil
+	w.activeRoutesMu.Unlock()
+	w.activeExcludeRoutes = nil
+}
+
+// recvTunFD читает сообщения helper'а до получения fd интерфейса.
+func recvTunFD(hconn *net.UnixConn, logf wgLogFunc) (*os.File, string, error) {
+	buf := make([]byte, 4096)
+	oob := make([]byte, 128)
+	var acc []byte
+	pendingFD := -1
+	hconn.SetReadDeadline(time.Now().Add(60 * time.Second))
+
+	for {
+		for {
+			i := bytes.IndexByte(acc, '\n')
+			if i < 0 {
+				break
+			}
+			line := acc[:i]
+			acc = acc[i+1:]
+			var msg wgHelperMsg
+			if json.Unmarshal(line, &msg) != nil {
+				continue
+			}
+			if msg.Log != "" {
+				logf(msg.Log)
+			}
+			if msg.Error != "" {
+				return nil, "", fmt.Errorf("helper: %s", msg.Error)
+			}
+			if msg.Name != "" {
+				if pendingFD < 0 {
+					return nil, "", fmt.Errorf("fd интерфейса %s не получен", msg.Name)
+				}
+				return os.NewFile(uintptr(pendingFD), msg.Name), msg.Name, nil
+			}
+		}
+
+		n, oobn, _, _, err := hconn.ReadMsgUnix(buf, oob)
+		if err != nil {
+			return nil, "", fmt.Errorf("чтение от helper: %w", err)
+		}
+		if oobn > 0 {
+			if scms, err := syscall.ParseSocketControlMessage(oob[:oobn]); err == nil {
+				for _, scm := range scms {
+					if fds, err := syscall.ParseUnixRights(&scm); err == nil && len(fds) > 0 {
+						pendingFD = fds[0]
+						syscall.CloseOnExec(fds[0])
+					}
+				}
+			}
+		}
+		acc = append(acc, buf[:n]...)
+	}
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func defaultGatewayDarwin() string {
+	out, err := exec.Command("route", "-n", "get", "default").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "gateway:" {
+			return fields[1]
+		}
+	}
+	return ""
+}
+
+func runCmdDarwin(name string, args ...string) error {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s %v: %w — %s", name, args, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ═══════════════════════════════════════════════════
+// HELPER SIDE (запускается от root: pwdtt --wg-helper …)
+// ═══════════════════════════════════════════════════
+
+// RunWGHelperDarwin — точка входа режима --wg-helper (вызывается из main_darwin.go).
+func RunWGHelperDarwin(args []string) {
+	fs := flag.NewFlagSet("wg-helper", flag.ExitOnError)
+	sockPath := fs.String("sock", "", "путь unix-сокета приложения")
+	addr := fs.String("addr", "", "адрес интерфейса (CIDR)")
+	mtu := fs.Int("mtu", 1300, "MTU")
+	excludes := fs.String("exclude", "", "exclude CIDR через запятую (мимо туннеля)")
+	tunnels := fs.String("tunnel", "", "туннельные CIDR через запятую")
+	fs.Parse(args)
+
+	raddr, err := net.ResolveUnixAddr("unix", *sockPath)
+	if err != nil {
+		os.Exit(1)
+	}
+	hconn, err := net.DialUnix("unix", nil, raddr)
+	if err != nil {
+		os.Exit(1)
+	}
+	defer hconn.Close()
+
+	send := func(msg wgHelperMsg, fd int) {
+		data, _ := json.Marshal(msg)
+		data = append(data, '\n')
+		if fd >= 0 {
+			hconn.WriteMsgUnix(data, syscall.UnixRights(fd), nil)
+		} else {
+			hconn.Write(data)
+		}
+	}
+	fail := func(format string, a ...any) {
+		send(wgHelperMsg{Error: fmt.Sprintf(format, a...)}, -1)
+		os.Exit(1)
+	}
+
+	if os.Geteuid() != 0 {
+		fail("helper запущен не от root (uid=%d)", os.Getuid())
+	}
+	if *addr == "" {
+		fail("не задан -addr")
+	}
+
+	dev, err := tun.CreateTUN("utun", *mtu)
+	if err != nil {
+		fail("create utun: %v", err)
+	}
+	name, err := dev.Name()
+	if err != nil {
+		fail("utun name: %v", err)
+	}
+	send(wgHelperMsg{Log: fmt.Sprintf("Создан интерфейс %s (mtu=%d)", name, *mtu)}, -1)
+
+	host := strings.SplitN(*addr, "/", 2)[0]
+	if err := runCmdDarwin("ifconfig", name, "inet", *addr, host, "alias"); err != nil {
+		fail("ifconfig: %v", err)
+	}
+	_ = runCmdDarwin("ifconfig", name, "up")
+	send(wgHelperMsg{Log: fmt.Sprintf("IP установлен: %s", *addr)}, -1)
+
+	gw := defaultGatewayDarwin()
+	send(wgHelperMsg{Log: fmt.Sprintf("Default gateway: %s", gw)}, -1)
+
+	// Exclude-маршруты через физический gateway — ДО туннельных,
+	// чтобы трафик к turn/VK не успел уйти в туннель
+	var added []string
+	if gw != "" {
+		for _, cidr := range splitCSV(*excludes) {
+			if err := runCmdDarwin("route", "-q", "-n", "add", "-net", cidr, gw); err != nil {
+				send(wgHelperMsg{Log: fmt.Sprintf("exclude route %s: %v", cidr, err)}, -1)
+			} else {
+				added = append(added, cidr)
+			}
+		}
+		send(wgHelperMsg{Log: fmt.Sprintf("Exclude-маршрутов добавлено: %d", len(added))}, -1)
+	}
+
+	for _, cidr := range splitCSV(*tunnels) {
+		if err := runCmdDarwin("route", "-q", "-n", "add", "-net", cidr, "-interface", name); err != nil {
+			send(wgHelperMsg{Log: fmt.Sprintf("tunnel route %s: %v", cidr, err)}, -1)
+		}
+	}
+
+	// Передаём fd интерфейса приложению
+	send(wgHelperMsg{Name: name}, int(dev.File().Fd()))
+
+	// Ждём "down" или обрыв соединения (краш приложения) → уборка
+	buf := make([]byte, 64)
+	for {
+		n, err := hconn.Read(buf)
+		if err != nil || strings.Contains(string(buf[:n]), "down") {
+			break
+		}
+	}
+	for _, cidr := range added {
+		_ = runCmdDarwin("route", "-q", "-n", "delete", "-net", cidr)
+	}
+	runtime.KeepAlive(dev)
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -1,0 +1,63 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleName</key>
+        <string>{{.Info.ProductName}}</string>
+        <key>CFBundleExecutable</key>
+        <string>{{.OutputFilename}}</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.wails.{{safeBundleID .Name}}</string>
+        <key>CFBundleVersion</key>
+        <string>{{.Info.ProductVersion}}</string>
+        <key>CFBundleGetInfoString</key>
+        <string>{{.Info.Comments}}</string>
+        <key>CFBundleShortVersionString</key>
+        <string>{{.Info.ProductVersion}}</string>
+        <key>CFBundleIconFile</key>
+        <string>iconfile</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>10.13.0</string>
+        <key>NSHighResolutionCapable</key>
+        <string>true</string>
+        <key>NSHumanReadableCopyright</key>
+        <string>{{.Info.Copyright}}</string>
+        {{if .Info.FileAssociations}}
+        <key>CFBundleDocumentTypes</key>
+        <array>
+          {{range .Info.FileAssociations}}
+          <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+              <string>{{.Ext}}</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>{{.Name}}</string>
+            <key>CFBundleTypeRole</key>
+            <string>{{.Role}}</string>
+            <key>CFBundleTypeIconFile</key>
+            <string>{{.IconName}}</string>
+          </dict>
+          {{end}}
+        </array>
+        {{end}}
+        {{if .Info.Protocols}}
+        <key>CFBundleURLTypes</key>
+        <array>
+          {{range .Info.Protocols}}
+            <dict>
+                <key>CFBundleURLName</key>
+                <string>com.wails.{{.Scheme}}</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>{{.Scheme}}</string>
+                </array>
+                <key>CFBundleTypeRole</key>
+                <string>{{.Role}}</string>
+            </dict>
+          {{end}}
+        </array>
+        {{end}}
+    </dict>
+</plist>

--- a/main_darwin.go
+++ b/main_darwin.go
@@ -1,0 +1,61 @@
+//go:build darwin
+
+package main
+
+import (
+	"embed"
+	"os"
+
+	"github.com/wailsapp/wails/v2"
+	"github.com/wailsapp/wails/v2/pkg/options"
+	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
+	"github.com/wailsapp/wails/v2/pkg/options/mac"
+
+	"pwdtt/backend"
+)
+
+//go:embed all:frontend/dist
+var assets embed.FS
+
+func main() {
+	// Привилегированный режим настройки туннеля (запускается от root через osascript).
+	// Перехватываем до инициализации GUI.
+	if len(os.Args) > 1 && os.Args[1] == "--wg-helper" {
+		backend.RunWGHelperDarwin(os.Args[2:])
+		return
+	}
+
+	app := backend.NewApp()
+
+	err := wails.Run(&options.App{
+		Title:     "PWDTT",
+		Width:     900,
+		Height:    600,
+		MinWidth:  800,
+		MinHeight: 550,
+		Frameless: false,
+		AssetServer: &assetserver.Options{
+			Assets: assets,
+		},
+		BackgroundColour: &options.RGBA{R: 255, G: 255, B: 255, A: 1},
+		OnStartup:        app.Startup,
+		Bind:             []interface{}{app},
+		Mac: &mac.Options{
+			TitleBar: &mac.TitleBar{
+				TitlebarAppearsTransparent: false,
+				HideTitle:                  false,
+				HideTitleBar:               false,
+				FullSizeContent:            false,
+				UseToolbar:                 false,
+				HideToolbarSeparator:       false,
+			},
+			About: &mac.AboutInfo{
+				Title:   "PWDTT",
+				Message: "© 2026 PWDTT",
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## Что это

Добавляет поддержку WireGuard на **macOS**. Раньше WG-слой был реализован только для Linux (kernel `ip`/`wg`) и Windows (userspace wireguard-go + wintun); на darwin `WG.Apply()` падал в `unsupported platform: darwin` — приложение собиралось, но туннель поднять не могло.

## Как сделано

Переиспользуется тот же **userspace wireguard-go**, что и в Windows-пути (на darwin он работает нативно через `utun`). Поскольку создание `utun` и правка маршрутов на macOS требуют root, туннель поднимается в два процесса:

- **App** (без прав) слушает unix-сокет и через `osascript` (`with administrator privileges`) запускает себя же в режиме `--wg-helper` от root.
- **Helper** (root) создаёт `utun`, назначает адрес/MTU и маршруты, отдаёт fd интерфейса приложению по `SCM_RIGHTS` и висит на сокете; команда `down` или обрыв соединения (краш app) → снимает exclude-маршруты и выходит.
- **App** оборачивает полученный fd в userspace wireguard-go и крутит крипту без прав. Приватный ключ helper'у не передаётся.

exclude-маршруты (turn/VK/DNS) идут через физический gateway мимо туннеля; полный туннель `0.0.0.0/0` разбивается на split-default `0/1`+`128/1`, чтобы не трогать физический default route (чистый teardown).

## Изменения

- `backend/wg_darwin.go` — реализация (app + helper).
- `backend/wg.go` — `case "darwin"` в `Apply`/`Teardown` + поле `helperConn`.
- `main_darwin.go`, `backend/cmd_darwin.go` — точка входа под darwin (`mac.Options`, перехват `--wg-helper`) и no-op `hideWindow`.
- `backend/autostart.go` — автозапуск через LaunchAgent (`~/Library/LaunchAgents`).
- `backend/update.go` — гибкий матчинг ассета релиза (`darwin`/`macos` + `universal`/`arm64`).
- `build/darwin/Info.plist` — конфиг упаковки .app (по аналогии с уже трекаемым `build/windows/`).

## Тестирование

Собрано `wails build -platform darwin/universal`. Проверено на живом сервере: туннель поднимается, трафик идёт, exclude-маршруты идут мимо туннеля, teardown корректно снимает интерфейс и маршруты. Отдельно прогнан app-путь с явным сбросом привилегий — оборачивание fd от root-хелпера и подъём wireguard-go работают без прав.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
