### PR TITLE
fix(macos): уборка exclude-маршрутов, переживших краш приложения

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -37,6 +37,11 @@ func (a *App) Startup(ctx context.Context) {
 	if settings.AutoStart {
 		a.SetAutoStart(true)
 	}
+
+	// Уборка маршрутов, оставшихся от краша прошлого запуска
+	go CleanupStaleExcludeRoutes(func(msg string) {
+		a.onBridgeEvent("log", "INFO", "[WG] "+msg)
+	})
 }
 
 // ═══════════════════════════════════════════════════

--- a/backend/wg.go
+++ b/backend/wg.go
@@ -61,6 +61,18 @@ func (w *WG) Apply(conf string, turnIPs []string, logf wgLogFunc) error {
 	}
 }
 
+// CleanupStaleExcludeRoutes убирает exclude-маршруты, оставшиеся после краша
+// прошлого запуска (когда helper не успел сделать уборку). Вызывать при
+// старте приложения; на платформах без такой проблемы — no-op.
+func CleanupStaleExcludeRoutes(logf wgLogFunc) {
+	if logf == nil {
+		logf = func(msg string) { log.Printf("[WG] %s", msg) }
+	}
+	if runtime.GOOS == "darwin" {
+		cleanupStaleExcludeRoutesDarwin(logf)
+	}
+}
+
 func (w *WG) Teardown() {
 	switch runtime.GOOS {
 	case "linux":

--- a/backend/wg_darwin.go
+++ b/backend/wg_darwin.go
@@ -256,6 +256,71 @@ func defaultGatewayDarwin() string {
 	return ""
 }
 
+// cleanupStaleExcludeRoutesDarwin — уборка exclude-маршрутов, переживших
+// краш приложения вместе с helper'ом: обычные (не -interface) маршруты сами
+// не исчезают и после смены сети ведут на мёртвый шлюз, глуша VK/Яндекс
+// даже при выключенном туннеле. Права администратора запрашиваются только
+// если протухшие маршруты действительно найдены.
+func cleanupStaleExcludeRoutesDarwin(logf wgLogFunc) {
+	curGW := defaultGatewayDarwin()
+	if curGW == "" {
+		return
+	}
+
+	// Протухший = специфичный маршрут из vkExcludeCIDRs, чей шлюз ≠ текущему
+	staleGWs := map[string]bool{}
+	for _, cidr := range vkExcludeCIDRs {
+		out, err := exec.Command("route", "-n", "get", strings.SplitN(cidr, "/", 2)[0]).Output()
+		if err != nil {
+			continue
+		}
+		var dst, gw string
+		for _, line := range strings.Split(string(out), "\n") {
+			f := strings.Fields(line)
+			if len(f) != 2 {
+				continue
+			}
+			switch f[0] {
+			case "destination:":
+				dst = f[1]
+			case "gateway:":
+				gw = f[1]
+			}
+		}
+		if dst != "" && dst != "default" && gw != "" && gw != curGW && net.ParseIP(gw) != nil {
+			staleGWs[gw] = true
+		}
+	}
+	if len(staleGWs) == 0 {
+		return
+	}
+
+	// Сносим все маршруты через мёртвые шлюзы — включая /32 на TURN-серверы
+	// и DNS, которые заранее не перечислить
+	out, err := exec.Command("netstat", "-rn", "-f", "inet").Output()
+	if err != nil {
+		return
+	}
+	var dels []string
+	for _, line := range strings.Split(string(out), "\n") {
+		f := strings.Fields(line)
+		if len(f) >= 2 && staleGWs[f[1]] {
+			dels = append(dels, "route -q -n delete -net "+shellQuote(f[0]))
+		}
+	}
+	if len(dels) == 0 {
+		return
+	}
+
+	logf(fmt.Sprintf("Найдены маршруты прошлого запуска через мёртвый шлюз (%d шт), удаляю…", len(dels)))
+	osa := fmt.Sprintf("do shell script %q with administrator privileges", strings.Join(dels, "; "))
+	if out, err := exec.Command("osascript", "-e", osa).CombinedOutput(); err != nil {
+		logf(fmt.Sprintf("уборка маршрутов не удалась: %v — %s", err, strings.TrimSpace(string(out))))
+		return
+	}
+	logf("Протухшие маршруты удалены")
+}
+
 func runCmdDarwin(name string, args ...string) error {
 	out, err := exec.Command(name, args...).CombinedOutput()
 	if err != nil {
@@ -334,6 +399,9 @@ func RunWGHelperDarwin(args []string) {
 	var added []string
 	if gw != "" {
 		for _, cidr := range splitCSV(*excludes) {
+			// Снимаем возможный остаток прошлого запуска (краш без уборки) —
+			// иначе add упрётся в старый маршрут с мёртвым шлюзом
+			_ = runCmdDarwin("route", "-q", "-n", "delete", "-net", cidr)
 			if err := runCmdDarwin("route", "-q", "-n", "add", "-net", cidr, gw); err != nil {
 				send(wgHelperMsg{Log: fmt.Sprintf("exclude route %s: %v", cidr, err)}, -1)
 			} else {


### PR DESCRIPTION
## Проблема

Exclude-маршруты (VK/Яндекс/DNS мимо туннеля) прописываются через текущий default gateway обычными записями таблицы маршрутизации. Если приложение падает **вместе с helper'ом** (kill -9, logout, паника) — уборка в helper'е не срабатывает, и маршруты остаются в системе навсегда.

После смены сети (другой Wi-Fi, хотспот → домашний роутер) они начинают вести на мёртвый шлюз — и VK, Яндекс, Mail.ru глохнут **даже при выключенном туннеле**, с невнятными ошибками в браузере (`ERR_SOCKS_CONNECTION_FAILED`, «Can't assign requested address»). Поймал это вживую: после сессии на хотспоте в таблице осталось 15 маршрутов на шлюз `10.223.175.129`, которого больше не существует.

## Решение — две линии защиты

1. **Helper перед `route add` снимает возможный остаток** прошлого запуска (`route delete` того же CIDR). Каждое подключение само чинит хвосты.
2. **Уборка при старте приложения** (`CleanupStaleExcludeRoutes`): без прав находит специфичные маршруты из `vkExcludeCIDRs`, чей шлюз ≠ текущему default gateway, затем сносит **все** маршруты через найденные мёртвые шлюзы — включая `/32` на TURN-серверы и DNS, которые заранее не перечислить. Диалог прав администратора появляется только если протухшие маршруты действительно найдены — при обычном запуске ничего не спрашивается.

На linux/windows функция — no-op (на linux exclude-маршруты снимаются через `activeRoutes`, на windows живут в wintun).

## Проверка

- `go build ./...` / `wails build` — чисто.
- Воспроизведение: подключение → `kill -9` приложения и helper'а → смена сети → VK недоступен. С фиксом: следующий запуск приложения находит и удаляет протухшие маршруты (лог в UI), VK оживает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)