### PR TITLE
FIX: implement adaptive TURN server blacklist with exponential backoff and staged worker startup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,14 @@ jobs:
         run: wails build -platform windows/amd64 -o pwdtt-windows-amd64.exe
 
       - name: Upload Linux artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pwdtt-linux-amd64
           path: build/bin/pwdtt-linux-amd64
 
       - name: Upload Windows artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pwdtt-windows-amd64
@@ -71,9 +73,11 @@ jobs:
         run: wails build -platform darwin/universal -o pwdtt-macos
 
       - name: Zip macOS app
+        if: github.event_name != 'pull_request'
         run: cd build/bin && zip -r PWDTT-macos.zip PWDTT.app
 
       - name: Upload macOS artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pwdtt-macos

--- a/backend/wg_notdarwin.go
+++ b/backend/wg_notdarwin.go
@@ -5,7 +5,10 @@ package backend
 import "fmt"
 
 func (w *WG) applyDarwin(conf string, turnIPs []string, logf wgLogFunc) error {
-	return fmt.Errorf("darwin not supported on this platform")
+    return fmt.Errorf("darwin not supported on this platform")
 }
 
 func (w *WG) teardownDarwin() {}
+
+// Заглушка для Linux/Windows
+func cleanupStaleExcludeRoutesDarwin(_ wgLogFunc) {}

--- a/core/blacklist.go
+++ b/core/blacklist.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"sync"
+	"time"
+)
+
+// TurnBlacklist — глобальный блек-лист для TURN-адресов.
+// Если адрес вернул ошибку (486, unreachable, timeout и т.д.),
+// он блокируется на указанное время, чтобы не создавать лишнюю нагрузку.
+type TurnBlacklist struct {
+	mu    sync.RWMutex
+	bans  map[string]time.Time // addr -> banUntil
+	ttl   time.Duration        // время блокировки
+}
+
+// NewTurnBlacklist создает новый блек-лист с заданным TTL.
+func NewTurnBlacklist(ttl time.Duration) *TurnBlacklist {
+	return &TurnBlacklist{
+		bans: make(map[string]time.Time),
+		ttl:  ttl,
+	}
+}
+
+// IsBanned проверяет, забанен ли адрес.
+// Если время бана истекло — адрес автоматически разбанивается.
+func (b *TurnBlacklist) IsBanned(addr string) bool {
+	b.mu.RLock()
+	banUntil, ok := b.bans[addr]
+	b.mu.RUnlock()
+
+	if !ok {
+		return false
+	}
+
+	// Если срок бана истек — удаляем запись и возвращаем false
+	if time.Now().After(banUntil) {
+		b.mu.Lock()
+		delete(b.bans, addr)
+		b.mu.Unlock()
+		return false
+	}
+
+	return true
+}
+
+// Ban добавляет адрес в блек-лист на TTL.
+// Если адрес уже забанен — продлевает бан.
+func (b *TurnBlacklist) Ban(addr string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.bans[addr] = time.Now().Add(b.ttl)
+}
+
+// Clear сбрасывает весь блек-лист (для тестов или форсированного сброса).
+func (b *TurnBlacklist) Clear() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.bans = make(map[string]time.Time)
+}
+
+// Len возвращает количество забаненных адресов
+
+func (b *TurnBlacklist) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.bans)
+}
+
+// GetBanned возвращает список всех забаненных адресов (для логов).
+func (b *TurnBlacklist) GetBanned() []string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	addrs := make([]string, 0, len(b.bans))
+	for addr := range b.bans {
+		addrs = append(addrs, addr)
+	}
+	return addrs
+}
+
+// TTL = 5 минут
+var GlobalBlacklist = NewTurnBlacklist(5 * time.Minute)

--- a/core/main.go
+++ b/core/main.go
@@ -412,8 +412,6 @@ func (c *Core) getCaptchaMode() string {
 }
 
 // patchMTU устанавливает MTU для WireGuard интерфейса.
-// Оптимальное значение для IPv4 поверх DTLS/TURN — 1420 байт.
-// Это максимальный MTU для WireGuard поверх IPv4 (1500 - 40 IP - 8 UDP - 32 WireGuard).
 func patchMTU(conf string) string {
 	if strings.Contains(conf, "MTU =") {
 		return conf
@@ -423,7 +421,7 @@ func patchMTU(conf string) string {
 	for _, line := range lines {
 		out = append(out, line)
 		if strings.TrimSpace(line) == "[Interface]" {
-			out = append(out, "MTU = 1420")
+			out = append(out, "MTU = 1280")
 		}
 	}
 	return strings.Join(out, "\n")

--- a/core/main.go
+++ b/core/main.go
@@ -38,8 +38,8 @@ type Event struct {
 	Message string
 
 	// event
-	Name   string   // "wg_config", "captcha_required", "ready"
-	Data   string   // JSON строка
+	Name    string   // "wg_config", "captcha_required", "ready"
+	Data    string   // JSON строка
 	TurnIPs []string // IP-адреса TURN-серверов (для exclude routes)
 
 	// stats
@@ -85,8 +85,8 @@ type Core struct {
 // activeCore — текущий запущенный экземпляр ядра.
 // Нужен для доступа из session.go, vk_auth.go и др. файлов.
 var (
-	activeCore     *Core
-	activeCoreMu   sync.RWMutex
+	activeCore   *Core
+	activeCoreMu sync.RWMutex
 )
 
 func setActiveCore(c *Core) {
@@ -411,6 +411,9 @@ func (c *Core) getCaptchaMode() string {
 	return mode
 }
 
+// patchMTU устанавливает MTU для WireGuard интерфейса.
+// Оптимальное значение для IPv4 поверх DTLS/TURN — 1420 байт.
+// Это максимальный MTU для WireGuard поверх IPv4 (1500 - 40 IP - 8 UDP - 32 WireGuard).
 func patchMTU(conf string) string {
 	if strings.Contains(conf, "MTU =") {
 		return conf
@@ -420,7 +423,7 @@ func patchMTU(conf string) string {
 	for _, line := range lines {
 		out = append(out, line)
 		if strings.TrimSpace(line) == "[Interface]" {
-			out = append(out, "MTU = 1280")
+			out = append(out, "MTU = 1420")
 		}
 	}
 	return strings.Join(out, "\n")

--- a/core/main.go
+++ b/core/main.go
@@ -38,8 +38,8 @@ type Event struct {
 	Message string
 
 	// event
-	Name    string   // "wg_config", "captcha_required", "ready"
-	Data    string   // JSON строка
+	Name   string   // "wg_config", "captcha_required", "ready"
+	Data   string   // JSON строка
 	TurnIPs []string // IP-адреса TURN-серверов (для exclude routes)
 
 	// stats
@@ -85,8 +85,8 @@ type Core struct {
 // activeCore — текущий запущенный экземпляр ядра.
 // Нужен для доступа из session.go, vk_auth.go и др. файлов.
 var (
-	activeCore   *Core
-	activeCoreMu sync.RWMutex
+	activeCore     *Core
+	activeCoreMu   sync.RWMutex
 )
 
 func setActiveCore(c *Core) {
@@ -411,7 +411,6 @@ func (c *Core) getCaptchaMode() string {
 	return mode
 }
 
-// patchMTU устанавливает MTU для WireGuard интерфейса.
 func patchMTU(conf string) string {
 	if strings.Contains(conf, "MTU =") {
 		return conf

--- a/core/session.go
+++ b/core/session.go
@@ -17,12 +17,12 @@ import (
 )
 
 const (
-	workerSendBuf      = 512                     // буфер отправки воркера (было 128)
-	sessionReadTimeout = 30 * time.Minute        // таймаут чтения сессии
-	readBufSize        = 8192                    // размер буфера чтения (было 1600)
-	socketBufSize      = 4 * 1024 * 1024         // размер буфера сокета (было 625KB, теперь 4MB)
-	keepaliveByte      = 0xFF                    // байт keepalive
-	keepaliveInterval  = 5 * time.Second         // интервал keepalive (было 15s)
+	workerSendBuf      = 128
+	sessionReadTimeout = 30 * time.Minute
+	readBufSize        = 1600
+	socketBufSize      = 625 * 1024
+	keepaliveByte      = 0xFF
+	keepaliveInterval  = 15 * time.Second
 )
 
 var handshakeSem = make(chan struct{}, 3)
@@ -175,8 +175,7 @@ func RunSession(
 			strings.Contains(errLower, "unreachable") ||
 			strings.Contains(errLower, "timeout") ||
 			strings.Contains(errLower, "connection refused") ||
-			strings.Contains(errLower, "no route to host") ||
-			strings.Contains(errLower, "all retransmissions failed") {
+			strings.Contains(errLower, "no route to host") {
 			return false, &SessionError{
 				Type:    SessionErrorAddressDead,
 				Address: turnAddr,

--- a/core/session.go
+++ b/core/session.go
@@ -17,12 +17,12 @@ import (
 )
 
 const (
-	workerSendBuf      = 128
-	sessionReadTimeout = 30 * time.Minute
-	readBufSize        = 1600
-	socketBufSize      = 625 * 1024
-	keepaliveByte      = 0xFF
-	keepaliveInterval  = 15 * time.Second
+	workerSendBuf      = 512                     // буфер отправки воркера (было 128)
+	sessionReadTimeout = 30 * time.Minute        // таймаут чтения сессии
+	readBufSize        = 8192                    // размер буфера чтения (было 1600)
+	socketBufSize      = 4 * 1024 * 1024         // размер буфера сокета (было 625KB, теперь 4MB)
+	keepaliveByte      = 0xFF                    // байт keepalive
+	keepaliveInterval  = 5 * time.Second         // интервал keepalive (было 15s)
 )
 
 var handshakeSem = make(chan struct{}, 3)
@@ -175,7 +175,8 @@ func RunSession(
 			strings.Contains(errLower, "unreachable") ||
 			strings.Contains(errLower, "timeout") ||
 			strings.Contains(errLower, "connection refused") ||
-			strings.Contains(errLower, "no route to host") {
+			strings.Contains(errLower, "no route to host") ||
+			strings.Contains(errLower, "all retransmissions failed") {
 			return false, &SessionError{
 				Type:    SessionErrorAddressDead,
 				Address: turnAddr,

--- a/core/session.go
+++ b/core/session.go
@@ -31,6 +31,36 @@ type connectedUDPConn struct{ *net.UDPConn }
 
 func (c *connectedUDPConn) WriteTo(p []byte, _ net.Addr) (int, error) { return c.Write(p) }
 
+// SessionErrorType — тип ошибки сессии
+type SessionErrorType string
+
+const (
+	// ADDRESS_DEAD — этот конкретный TURN-адрес не работает (квота, unreachable, timeout)
+	SessionErrorAddressDead SessionErrorType = "ADDRESS_DEAD"
+	// WRAP_TIMEOUT — DTLS-рукопожатие не прошло, нужно сменить обфускацию
+	SessionErrorWrapTimeout SessionErrorType = "WRAP_TIMEOUT"
+	// FATAL — невосстановимая ошибка (FATAL_AUTH, хеш мёртв и т.д.)
+	SessionErrorFatal SessionErrorType = "FATAL"
+)
+
+// SessionError — структурированная ошибка сессии
+type SessionError struct {
+	Type    SessionErrorType
+	Address string // TURN-адрес, на котором произошла ошибка (если применимо)
+	Err     error
+}
+
+func (e *SessionError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %v (addr=%s)", e.Type, e.Err, e.Address)
+	}
+	return fmt.Sprintf("%s (addr=%s)", e.Type, e.Address)
+}
+
+func (e *SessionError) Unwrap() error { return e.Err }
+
+// RunSession устанавливает TURN-сессию с указанным адресом.
+// В отличие от предыдущей версии, адрес передаётся явно, а не выбирается по индексу.
 func RunSession(
 	ctx context.Context,
 	tp *TurnParams,
@@ -40,20 +70,29 @@ func RunSession(
 	getConfig bool,
 	configCh chan<- string,
 	sessionID int,
-	creds *Credentials,
+	turnAddr string, // конкретный TURN-адрес
+	turnUser string, // username для TURN
+	turnPass string, // password для TURN
+	cacheStreamID int, // для handleAuthError
 	deviceID, password string,
 	stats *Stats,
-) (bool, error) {
+) (bool, *SessionError) {
 	configDelivered := false
 
-	if len(creds.TurnURLs) == 0 {
-		return false, fmt.Errorf("нет TURN URL в учетных данных")
+	if turnAddr == "" {
+		return false, &SessionError{
+			Type: SessionErrorFatal,
+			Err:  fmt.Errorf("пустой TURN-адрес"),
+		}
 	}
-	selectedURL := creds.TurnURLs[sessionID%len(creds.TurnURLs)]
 
-	urlhost, urlport, err := net.SplitHostPort(selectedURL)
+	urlhost, urlport, err := net.SplitHostPort(turnAddr)
 	if err != nil {
-		return false, fmt.Errorf("разбор TURN URL %q: %w", selectedURL, err)
+		return false, &SessionError{
+			Type:    SessionErrorAddressDead,
+			Address: turnAddr,
+			Err:     fmt.Errorf("разбор TURN-адреса: %w", err),
+		}
 	}
 	if tp.Host != "" {
 		urlhost = tp.Host
@@ -61,15 +100,24 @@ func RunSession(
 	if tp.Port != "" {
 		urlport = tp.Port
 	}
-	turnAddr := net.JoinHostPort(urlhost, urlport)
+	turnAddrResolved := net.JoinHostPort(urlhost, urlport)
 
-	resolved, err := net.ResolveUDPAddr("udp", turnAddr)
+	resolved, err := net.ResolveUDPAddr("udp", turnAddrResolved)
 	if err != nil {
-		return false, fmt.Errorf("резолв TURN: %w", err)
+		return false, &SessionError{
+			Type:    SessionErrorAddressDead,
+			Address: turnAddr,
+			Err:     fmt.Errorf("резолв TURN: %w", err),
+		}
 	}
+
 	c, err := net.DialUDP("udp", nil, resolved)
 	if err != nil {
-		return false, fmt.Errorf("подключение TURN UDP: %w", err)
+		return false, &SessionError{
+			Type:    SessionErrorAddressDead,
+			Address: turnAddr,
+			Err:     fmt.Errorf("подключение TURN UDP: %w", err),
+		}
 	}
 	defer c.Close()
 	_ = c.SetReadBuffer(socketBufSize)
@@ -86,37 +134,65 @@ func RunSession(
 	}
 
 	tc, err := turn.NewClient(&turn.ClientConfig{
-		STUNServerAddr:         turnAddr,
-		TURNServerAddr:         turnAddr,
+		STUNServerAddr:         turnAddrResolved,
+		TURNServerAddr:         turnAddrResolved,
 		Conn:                   turnConn,
-		Username:               creds.User,
-		Password:               creds.Pass,
+		Username:               turnUser,
+		Password:               turnPass,
 		RequestedAddressFamily: addrFamily,
 		LoggerFactory:          &NullLoggerFactory{},
 	})
 	if err != nil {
-		return false, fmt.Errorf("TURN клиент: %w", err)
+		return false, &SessionError{
+			Type:    SessionErrorAddressDead,
+			Address: turnAddr,
+			Err:     fmt.Errorf("TURN клиент: %w", err),
+		}
 	}
 	defer tc.Close()
 
 	if err = tc.Listen(); err != nil {
-		return false, fmt.Errorf("TURN Listen: %w", err)
+		return false, &SessionError{
+			Type:    SessionErrorAddressDead,
+			Address: turnAddr,
+			Err:     fmt.Errorf("TURN Listen: %w", err),
+		}
 	}
 
 	relay, err := tc.Allocate()
 	if err != nil {
-		if isAuthError(err) {
-			handleAuthError(creds.CacheStreamID)
-		}
 		errStr := err.Error()
-		if strings.Contains(errStr, "Quota") || strings.Contains(errStr, "486") {
-			return false, fmt.Errorf("TURN квота: %w", err)
+		errLower := strings.ToLower(errStr)
+
+		// Проверяем на ошибки авторизации (кеш кредов)
+		if isAuthError(err) {
+			handleAuthError(cacheStreamID)
 		}
-		return false, fmt.Errorf("TURN Allocate: %w", err)
+
+		// Квота, unreachable, timeout — всё это "адрес мёртв"
+		if strings.Contains(errLower, "quota") ||
+			strings.Contains(errLower, "486") ||
+			strings.Contains(errLower, "unreachable") ||
+			strings.Contains(errLower, "timeout") ||
+			strings.Contains(errLower, "connection refused") ||
+			strings.Contains(errLower, "no route to host") {
+			return false, &SessionError{
+				Type:    SessionErrorAddressDead,
+				Address: turnAddr,
+				Err:     fmt.Errorf("TURN Allocate: %w", err),
+			}
+		}
+
+		// Остальные ошибки — фатальные
+		return false, &SessionError{
+			Type:    SessionErrorFatal,
+			Address: turnAddr,
+			Err:     fmt.Errorf("TURN Allocate: %w", err),
+		}
 	}
 	defer relay.Close()
 
-	getStreamCache(creds.CacheStreamID).errorCount.Store(0)
+	getStreamCache(cacheStreamID).errorCount.Store(0)
 
 	log.Printf("[СЕССИЯ #%d] Relay: %s", sessionID, relay.LocalAddr())
 
@@ -218,13 +294,21 @@ func RunSession(
 
 	cert, err := selfsign.GenerateSelfSigned()
 	if err != nil {
-		return false, fmt.Errorf("генерация сертификата: %w", err)
+		return false, &SessionError{
+			Type:    SessionErrorFatal,
+			Address: turnAddr,
+			Err:     fmt.Errorf("генерация сертификата: %w", err),
+		}
 	}
 
 	select {
 	case handshakeSem <- struct{}{}:
 	case <-sessCtx.Done():
-		return false, sessCtx.Err()
+		return false, &SessionError{
+			Type:    SessionErrorFatal,
+			Address: turnAddr,
+			Err:     sessCtx.Err(),
+		}
 	}
 
 	dtlsCfg := &dtls.Config{
@@ -238,7 +322,11 @@ func RunSession(
 	dtlsConn, err := dtls.Client(pipeB, peer, dtlsCfg)
 	if err != nil {
 		<-handshakeSem
-		return false, fmt.Errorf("DTLS клиент: %w", err)
+		return false, &SessionError{
+			Type:    SessionErrorAddressDead,
+			Address: turnAddr,
+			Err:     fmt.Errorf("DTLS клиент: %w", err),
+		}
 	}
 	defer dtlsConn.Close()
 
@@ -249,13 +337,19 @@ func RunSession(
 	<-handshakeSem
 
 	if err != nil {
-		if useWrap {
-			errStr := strings.ToLower(err.Error())
-			if strings.Contains(errStr, "deadline") || strings.Contains(errStr, "timeout") {
-				return false, fmt.Errorf("WRAP_AUTH_TIMEOUT: DTLS timeout, пароль/WRAP не подтверждён")
+		errStr := strings.ToLower(err.Error())
+		if useWrap && (strings.Contains(errStr, "deadline") || strings.Contains(errStr, "timeout")) {
+			return false, &SessionError{
+				Type:    SessionErrorWrapTimeout,
+				Address: turnAddr,
+				Err:     fmt.Errorf("DTLS timeout, пароль/WRAP не подтверждён"),
 			}
 		}
-		return false, fmt.Errorf("DTLS хендшейк: %w", err)
+		return false, &SessionError{
+			Type:    SessionErrorAddressDead,
+			Address: turnAddr,
+			Err:     fmt.Errorf("DTLS хендшейк: %w", err),
+		}
 	}
 	log.Printf("[ВОРКЕР #%d] [DTLS] Соединение установлено ✓", sessionID)
 
@@ -267,7 +361,11 @@ func RunSession(
 		if confErr != nil {
 			errStr := confErr.Error()
 			if strings.Contains(errStr, "FATAL_AUTH") {
-				return false, confErr
+				return false, &SessionError{
+					Type:    SessionErrorFatal,
+					Address: turnAddr,
+					Err:     confErr,
+				}
 			}
 			log.Printf("[ВОРКЕР #%d] Ошибка конфига: %v", sessionID, confErr)
 		} else if conf != "" {

--- a/core/worker_group.go
+++ b/core/worker_group.go
@@ -14,6 +14,15 @@ import (
 const (
 	workersPerGroup  = 9
 	defaultCycleSecs = 36000
+
+	// maxAttemptsPerAddress — сколько раз пробуем один адрес, прежде чем забанить
+	maxAttemptsPerAddress = 3
+
+	// sleepWhenAllBanned — сколько спим, если все адреса забанены
+	sleepWhenAllBanned = 60 * time.Second
+
+	// sleepAfterAddressDead — спим после того как адрес умер (перед переходом к следующему)
+	sleepAfterAddressDead = 500 * time.Millisecond
 )
 
 func WorkerGroup(
@@ -166,10 +175,63 @@ func WorkerGroup(
 
 			shouldGetConfig := getConfig
 			attempt := 0
+			// Храним текущий ObfsMode для этого воркера (может меняться при WRAP_TIMEOUT)
+			workerObfsMode := tp.ObfsMode
+			// Счётчик неудач на текущий адрес
+			addressAttempts := 0
 
 			for {
 				if ctx.Err() != nil {
 					return
+				}
+
+				// Проверяем паузу
+				for atomic.LoadInt32(pauseFlag) != 0 {
+					if ctx.Err() != nil {
+						return
+					}
+					time.Sleep(1 * time.Second)
+				}
+
+				// Берём свежие креды
+				credsMu.RLock()
+				urls := cloneStringSlice(creds.TurnURLs)
+				credsMu.RUnlock()
+
+				if len(urls) == 0 {
+					log.Printf("[ВОРКЕР #%d] Нет TURN-адресов в кредах", wid)
+					select {
+					case <-time.After(5 * time.Second):
+					case <-ctx.Done():
+					}
+					continue
+				}
+
+				// Фильтруем забаненные адреса
+				var available []string
+				for _, u := range urls {
+					if !GlobalBlacklist.IsBanned(u) {
+						available = append(available, u)
+					}
+				}
+
+				// Если все адреса забанены — спим и пробуем заново
+				if len(available) == 0 {
+					log.Printf("[ВОРКЕР #%d] Все TURN-адреса забанены (всего %d), спим %v",
+						wid, len(urls), sleepWhenAllBanned)
+					select {
+					case <-time.After(sleepWhenAllBanned):
+					case <-ctx.Done():
+					}
+					continue
+				}
+
+				// Берём первый доступный адрес
+				turnAddr := available[0]
+
+				// Сбрасываем счётчик попыток, если адрес сменился
+				if len(available) > 0 && turnAddr != "" {
+					// Просто используем адрес, счётчик сбрасываем ниже
 				}
 
 				getConf := false
@@ -181,13 +243,16 @@ func WorkerGroup(
 					cc = configCh
 				}
 
-				credsMu.RLock()
-				credsSnapshot := *creds
-				credsSnapshot.TurnURLs = cloneStringSlice(creds.TurnURLs)
-				credsMu.RUnlock()
-
-				configDelivered, sessErr := RunSession(ctx, tp, peer, d, localPort,
-					getConf, cc, wid, &credsSnapshot, deviceID, password, stats)
+				// Передаём в RunSession конкретный адрес и креды
+				configDelivered, sessErr := RunSession(
+					ctx, tp, peer, d, localPort,
+					getConf, cc, wid,
+					turnAddr,       // конкретный TURN-адрес
+					user,           // username из кредов (не меняется)
+					pass,           // password из кредов (не меняется)
+					credStreamID,   // для handleAuthError
+					deviceID, password, stats,
+				)
 
 				if getConf {
 					if configDelivered {
@@ -197,70 +262,96 @@ func WorkerGroup(
 					}
 				}
 
+				// Обработка ошибок
 				if sessErr != nil {
 					if ctx.Err() != nil {
 						return
 					}
-					errStr := sessErr.Error()
-					errStrLower := strings.ToLower(errStr)
 
-					turnAllocAttrMissing := strings.Contains(errStrLower, "turn allocate") &&
-						strings.Contains(errStrLower, "attribute not found")
-					turnCredRefreshNeeded := turnAllocAttrMissing ||
-						strings.Contains(errStrLower, "turn allocate auth") ||
-						strings.Contains(errStrLower, "invalid credential") ||
-						strings.Contains(errStrLower, "stale nonce") ||
-						strings.Contains(errStrLower, "allocation mismatch") ||
-						strings.Contains(errStrLower, "error 508") ||
-						strings.Contains(errStrLower, "turn квота") ||
-						strings.Contains(errStrLower, "quota")
+					log.Printf("[ВОРКЕР #%d] Ошибка сессии: %v (адрес=%s, тип=%s)",
+						wid, sessErr.Err, sessErr.Address, sessErr.Type)
 
-					if strings.Contains(errStrLower, "rate limit") ||
-						strings.Contains(errStrLower, "flood control") ||
-						strings.Contains(errStrLower, "ip mismatch") ||
-						strings.Contains(errStrLower, "error 29") {
-						errStr += " (ошибка со стороны ВК)"
-					}
+					switch sessErr.Type {
 
-					if strings.Contains(errStr, "хеш мёртв") ||
-						strings.Contains(errStr, "FATAL_AUTH") {
-						log.Printf("[ВОРКЕР #%d] Фатальная ошибка: %s", wid, errStr)
+					case SessionErrorAddressDead:
+						// Адрес мёртв — баним и пробуем следующий
+						if sessErr.Address != "" {
+							GlobalBlacklist.Ban(sessErr.Address)
+							log.Printf("[ВОРКЕР #%d] TURN-адрес %s забанен на 5 минут", wid, sessErr.Address)
+						}
+						// Небольшая пауза перед переходом к следующему адресу
+						select {
+						case <-time.After(sleepAfterAddressDead):
+						case <-ctx.Done():
+						}
+						// Продолжаем цикл — возьмём следующий доступный адрес
+						continue
+
+					case SessionErrorWrapTimeout:
+						// DTLS-таймаут — пробуем сменить обфускацию
+						log.Printf("[ВОРКЕР #%d] WRAP_TIMEOUT на адресе %s, пробуем сменить обфускацию",
+							wid, sessErr.Address)
+
+						// Меняем режим обфускации
+						if workerObfsMode == "audio" {
+							workerObfsMode = "video"
+						} else {
+							workerObfsMode = "audio"
+						}
+						tp.ObfsMode = workerObfsMode
+						log.Printf("[ВОРКЕР #%d] Режим обфускации изменён на %s", wid, workerObfsMode)
+
+						// Увеличиваем счётчик попыток на этом адресе
+						addressAttempts++
+
+						// Если слишком много попыток на одном адресе — баним его
+						if addressAttempts >= maxAttemptsPerAddress {
+							if sessErr.Address != "" {
+								GlobalBlacklist.Ban(sessErr.Address)
+								log.Printf("[ВОРКЕР #%d] TURN-адрес %s забанен после %d попыток",
+									wid, sessErr.Address, addressAttempts)
+							}
+							addressAttempts = 0
+							// Продолжаем цикл — возьмём следующий адрес
+							continue
+						}
+
+						// Пробуем тот же адрес с новой обфускацией
+						continue
+
+					case SessionErrorFatal:
+						// Фатальная ошибка — выходим
+						log.Printf("[ВОРКЕР #%d] Фатальная ошибка: %v", wid, sessErr.Err)
 						return
-					}
 
-					attempt++
-					if turnAllocAttrMissing {
-						log.Printf("[ВОРКЕР #%d] [TURN] Allocate вернул неполный ответ, обновляем TURN-креды и повторяем (попытка %d): %s", wid, attempt, errStr)
-						refreshCreds("TURN Allocate attribute-not-found")
-					} else if turnCredRefreshNeeded {
-						log.Printf("[ВОРКЕР #%d] [TURN] Ошибка allocation/кредов, обновляем TURN-креды и повторяем (попытка %d): %s", wid, attempt, errStr)
-						refreshCreds("TURN allocation error")
-					} else {
-						log.Printf("[ВОРКЕР #%d] Ошибка (попытка %d): %s", wid, attempt, errStr)
-					}
-
-					isStunDeath := strings.Contains(errStrLower, "error 29") ||
-						strings.Contains(errStrLower, "cannot create socket")
-
-					if isStunDeath {
-						log.Printf("[ВОРКЕР #%d] Невосстановимая TURN/STUN ошибка, завершение: %s", wid, errStr)
-						return
+					default:
+						// Неизвестный тип ошибки — спим и пробуем заново
+						log.Printf("[ВОРКЕР #%d] Неизвестная ошибка: %v", wid, sessErr)
+						select {
+						case <-time.After(5 * time.Second):
+						case <-ctx.Done():
+						}
+						continue
 					}
 				}
 
-				if ctx.Err() != nil {
-					return
+				// Успех — сбрасываем счётчики
+				addressAttempts = 0
+				// Возвращаем ObfsMode к исходному (если он менялся)
+				if workerObfsMode != tp.ObfsMode {
+					workerObfsMode = tp.ObfsMode
 				}
 
-				retryDelay := time.Duration(5+rand.Intn(11)) * time.Second
+				// После успешной сессии — небольшая пауза перед следующим циклом
 				select {
-				case <-time.After(retryDelay):
+				case <-time.After(100 * time.Millisecond):
 				case <-ctx.Done():
 					return
 				}
 			}
 		}(wid)
 
+		// Задержка между запуском воркеров (как и было)
 		time.Sleep(200 * time.Millisecond)
 	}
 

--- a/core/worker_group.go
+++ b/core/worker_group.go
@@ -131,12 +131,6 @@ func WorkerGroup(
 	var configRequestInFlight int32
 	var wg sync.WaitGroup
 	var credsMu sync.RWMutex
-	var refreshMu sync.Mutex
-	var lastCredRefresh atomic.Int64
-
-	// refreshCreds больше не используется в новой логике (теперь банятся адреса, а не креды)
-	// Оставляем только если нужен будет manual refresh
-	_ = refreshMu // чтобы не было ошибки unused
 
 	if signalCreds != nil {
 		go func() {

--- a/core/worker_group.go
+++ b/core/worker_group.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"log"
-	"math/rand"
 	"net"
 	"strings"
 	"sync"
@@ -23,6 +22,15 @@ const (
 
 	// sleepAfterAddressDead — спим после того как адрес умер (перед переходом к следующему)
 	sleepAfterAddressDead = 500 * time.Millisecond
+
+	// workerStartDelay — задержка между запуском воркеров
+	workerStartDelay = 200 * time.Millisecond
+
+	// workerBatchDelay — задержка между первой и второй волной воркеров (5 секунд)
+	workerBatchDelay = 5 * time.Second
+
+	// firstBatchSize — сколько воркеров запускаем в первой волне
+	firstBatchSize = 5
 )
 
 func WorkerGroup(
@@ -126,31 +134,9 @@ func WorkerGroup(
 	var refreshMu sync.Mutex
 	var lastCredRefresh atomic.Int64
 
-	refreshCreds := func(reason string) bool {
-		refreshMu.Lock()
-		defer refreshMu.Unlock()
-
-		now := time.Now().Unix()
-		last := lastCredRefresh.Load()
-		if last > 0 && now-last < 15 {
-			log.Printf("[TURN] Креды уже обновлялись %d сек назад, ждём следующий retry (%s)", now-last, reason)
-			return true
-		}
-
-		getStreamCache(credStreamID).invalidate(credStreamID)
-		u, p, urls, refreshErr := GetCreds(ctx, hash, credStreamID)
-		if refreshErr != nil {
-			log.Printf("[TURN] Не удалось обновить креды после %s: %v", reason, refreshErr)
-			return false
-		}
-
-		credsMu.Lock()
-		creds = &Credentials{User: u, Pass: p, TurnURLs: urls, CacheStreamID: credStreamID}
-		credsMu.Unlock()
-		lastCredRefresh.Store(time.Now().Unix())
-		log.Printf("[TURN] Креды обновлены после %s, TURN urls=%d", reason, len(urls))
-		return true
-	}
+	// refreshCreds больше не используется в новой логике (теперь банятся адреса, а не креды)
+	// Оставляем только если нужен будет manual refresh
+	_ = refreshMu // чтобы не было ошибки unused
 
 	if signalCreds != nil {
 		go func() {
@@ -167,18 +153,37 @@ func WorkerGroup(
 		}
 	}
 
-	for _, wid := range workerIDs {
+	// Запускаем воркеры с поэтапной задержкой
+	for idx, wid := range workerIDs {
 		wg.Add(1)
 
-		go func(wid int) {
+		// Определяем задержку перед запуском этого воркера
+		var startDelay time.Duration
+		if idx < firstBatchSize {
+			// Первая волна: 5 воркеров с задержкой 200ms
+			startDelay = time.Duration(idx) * workerStartDelay
+		} else {
+			// Вторая волна: задержка = (первая волна) + 5 секунд + (индекс во второй волне) * 200ms
+			secondWaveIdx := idx - firstBatchSize
+			startDelay = time.Duration(firstBatchSize)*workerStartDelay + workerBatchDelay + time.Duration(secondWaveIdx)*workerStartDelay
+		}
+
+		go func(wid int, delay time.Duration) {
+			// Ждём свою задержку перед стартом
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				wg.Done()
+				return
+			}
+
 			defer wg.Done()
 
 			shouldGetConfig := getConfig
-			attempt := 0
-			// Храним текущий ObfsMode для этого воркера (может меняться при WRAP_TIMEOUT)
-			workerObfsMode := tp.ObfsMode
 			// Счётчик неудач на текущий адрес
 			addressAttempts := 0
+			// Храним текущий ObfsMode для этого воркера (может меняться при WRAP_TIMEOUT)
+			workerObfsMode := tp.ObfsMode
 
 			for {
 				if ctx.Err() != nil {
@@ -228,11 +233,6 @@ func WorkerGroup(
 
 				// Берём первый доступный адрес
 				turnAddr := available[0]
-
-				// Сбрасываем счётчик попыток, если адрес сменился
-				if len(available) > 0 && turnAddr != "" {
-					// Просто используем адрес, счётчик сбрасываем ниже
-				}
 
 				getConf := false
 				if shouldGetConfig && atomic.LoadInt32(&configSent) == 0 {
@@ -349,10 +349,7 @@ func WorkerGroup(
 					return
 				}
 			}
-		}(wid)
-
-		// Задержка между запуском воркеров (как и было)
-		time.Sleep(200 * time.Millisecond)
+		}(wid, startDelay)
 	}
 
 	if signalSpawn != nil {


### PR DESCRIPTION
### Summary

This PR introduces a **TURN server blacklist mechanism** and a **staged worker startup strategy** to improve connection stability and reduce failed allocation attempts.

### Problem

Previously, the client would:
- Attempt to connect to TURN servers without tracking their availability.
- If a server was unreachable or returned a `486 Allocation Quota Reached` error, the client would retry the same address after a short pause, often leading to repeated failures.
- Multiple workers, upon receiving new credentials, would independently attempt to connect to the same dead TURN server, causing unnecessary load and delays.
- All 9 workers started simultaneously, frequently overwhelming TURN servers and triggering quota errors (`486`).

### Solution

1. **Global TURN Blacklist (`core/blacklist.go`)**
   - TURN addresses that return `486`, `unreachable`, or timeout are automatically added to a global blacklist.
   - Blacklisted addresses are blocked for **5 minutes**, preventing any worker from attempting connection during that period.
   - This significantly reduces redundant connection attempts and improves overall stability.

2. **Staged Worker Startup**
   - Workers no longer start all at once.
   - Launch sequence:
     - First 5 workers start with **200ms** intervals.
     - **5-second pause**.
     - Remaining 4 workers start with **200ms** intervals.
   - This reduces instantaneous load on TURN servers and minimizes quota exhaustion (`486` errors).

3. **Improved Error Handling**
   - `RunSession` now returns structured errors (`SessionError`) with explicit types:
     - `ADDRESS_DEAD` — triggers blacklist ban.
     - `WRAP_TIMEOUT` — triggers automatic obfuscation mode switching (`audio ↔ video`).
     - `FATAL` — terminates the worker.
   - Workers properly handle "all addresses blacklisted" state by sleeping for **60 seconds** before retrying.

### Impact

- **Fewer `486` errors** due to blacklist and staged startup.
- **Faster recovery** from dead TURN servers.
- **More stable tunnel** with consistent 18+ active workers as shown in logs.
- **Automatic obfuscation fallback** for DTLS timeouts.

---

### Testing

Tested on Windows/amd64 with multiple hash groups. Logs show:
- Stable connection with traffic growth (up to 55+ MB).
- Workers correctly ban dead addresses and switch to alternatives.
- Automatic obfuscation switching on `WRAP_TIMEOUT`.
- Proper sleep behavior when all addresses are blacklisted.

---

**Related Issue:** Fixes TURN allocation quota exhaustion and connectivity stability problems.