### PR TITLE
Fix worker authentication with newer qWDTT servers

### DIFF
--- a/core/protocol.go
+++ b/core/protocol.go
@@ -44,3 +44,12 @@ func RequestConfig(conn net.Conn, localPort, deviceID, password string) (string,
 
 	return resp, nil
 }
+
+// SendAuth авторизует рабочую DTLS-сессию, которая не запрашивает WireGuard-конфиг.
+func SendAuth(conn net.Conn, deviceID, password string) error {
+	payload := fmt.Sprintf("AUTH:%s|%s", deviceID, password)
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		return fmt.Errorf("отправка AUTH: %w", err)
+	}
+	return nil
+}

--- a/core/session.go
+++ b/core/session.go
@@ -380,6 +380,10 @@ func RunSession(
 		} else {
 			log.Printf("[ВОРКЕР #%d] Сервер ещё не выдал WireGuard-конфиг, повторим позже", sessionID)
 		}
+	} else {
+		if authErr := SendAuth(dtlsConn, deviceID, password); authErr != nil {
+			log.Printf("[ВОРКЕР #%d] Ошибка авторизации: %v", sessionID, authErr)
+		}
 	}
 
 	emitReady()


### PR DESCRIPTION
Fixes #27.

Newer qWDTT servers require every DTLS connection to authenticate using either GETCONF or AUTH.

PWDTT currently sends GETCONF only from the worker that requests the WireGuard configuration. Other workers successfully complete the DTLS handshake but do not authenticate, so newer qWDTT servers immediately close those connections. This causes repeated:

Reader: EOF

Changes:
- added SendAuth(conn, deviceID, password) using AUTH:<deviceID>|<password>;
- workers that do not request the WireGuard configuration now send AUTH before entering the normal proxy loop;
- existing GETCONF behaviour remains unchanged.

Testing:
- Windows Wails production build completed successfully;
- the fix was tested against a newer qWDTT server and stopped the immediate mass worker disconnects;
- go test ./... currently has pre-existing unrelated failures in store_test.go on Windows and those failures are unrelated to this change.

The code changes and this pull request description were prepared with the assistance of an AI coding assistant. The resulting Windows build was then tested manually.